### PR TITLE
build for additional platforms and containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
       - main
       - 'release/**'
 
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
 jobs:
   #
   # golangci-lint
@@ -43,47 +48,81 @@ jobs:
     name: Project Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
-
     steps:
-      - uses: actions/setup-go@v3
+      -
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
-      - uses: actions/checkout@v3
+      -
+        uses: actions/checkout@v3
         with:
           path: src/github.com/uor-framework/client
-      - name: verify go modules and vendor directory
+      -
+        name: verify go modules and vendor directory
         run: |
           make vendor
         working-directory: src/github.com/uor-framework/client
-      - name: running unit tests
+      -
+        name: running unit tests
         run: |
           make test-unit
         working-directory: src/github.com/uor-framework/client
-      - name: running sanity checks
+      -
+        name: running sanity checks
         run: |
           make sanity
         working-directory: src/github.com/uor-framework/client
 
-    # Release
+  # Release
   release:  
     needs: [linters, project]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v3
+    -
+      name: Checkout Repo
+      uses: actions/checkout@v3
+      id: clone
       with:
           fetch-depth: 0
-    - uses: actions/setup-go@v3
+    -
+      name: Install Cosign
+      uses: sigstore/cosign-installer@v2.4.1
+      id: cosign
+    -
+      name: Install SBOM
+      uses: anchore/sbom-action/download-syft@v0.11.0
+      id: sbom
+    -
+      name: Install QEMU
+      uses: docker/setup-qemu-action@v2
+      id: qemu
+    -
+      name: Install BUILDX
+      uses: docker/setup-buildx-action@v2
+      id: buildx
+      with:
+        install: true
+    -
+      name: Install Go
+      uses: actions/setup-go@v3
+      id: go
       with:
         go-version: 1.17
-    - name: release with goreleaser
+    -
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Run GoReleaser
       id: goreleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: latest
+        distribution: goreleaser
+        version: v1.10.2
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dataset-config.yaml
 tags
 *.swp
 .vscode
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,32 +1,138 @@
 project_name: client
 
+env:
+- GO111MODULE=on
+- COSIGN_EXPERIMENTAL=true
+
 before:
   hooks:
     - go mod tidy
     - go mod vendor
-
 builds:
-  - id: linux-amd64
-    binary: client-linux-{{ .Arch }}
+  -
+    binary: client-{{ .Os }}-{{ .Arch }}
+    no_unique_dist_dir: true
     main: ./cmd/client
-    ldflags:
-      - "-X github.com/uor-framework/client/cli.version={{ .Version }}"
-      - "-X github.com/uor-framework/client/cli.commit={{ .ShortCommit }}"
-      - "-X github.com/uor-framework/client/cli.buildDate={{ .Date }}"
+    flags:
+      - -trimpath
+    mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - linux
-    goarch:
-      - amd64
-    no_unique_dist_dir: true
-  
-  - id: darwin-amd64
-    binary: client-darwin-{{ .Arch }}
-    main: ./cmd/client
-    goos:
       - darwin
+      - windows
     goarch:
       - amd64
-    no_unique_dist_dir: true
+      - arm64
+      - arm
+      - s390x
+      - ppc64le
+    goarm:
+      - "7"
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: s390x
+      - goos: darwin
+        goarch: ppc64le
+    ldflags:
+      - "-X github.com/uor-framework/client/cli.version={{ .Tag }}"
+      - "-X github.com/uor-framework/client/cli.commit={{ .ShortCommit }}"
+      - "-X github.com/uor-framework/client/cli.buildDate={{ .Date }}"
+    env:
+      - CGO_ENABLED=0
+  
+signs:
+- id: client-keyless
+  signature: "${artifact}.sig"
+  certificate: "${artifact}.pem"
+  env:
+  - COSIGN_EXPERIMENTAL=1
+  cmd: cosign
+  args:
+    - sign-blob
+    - "--output-certificate=${certificate}"
+    - "--output-signature=${signature}"
+    - "${artifact}"
+  artifacts: binary
+  output: true
+
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
+    replacements:
+      linux: Linux
+      darwin: Darwin
+      windows: Windows
+      amd64: x86_64
+
+sboms:
+- artifacts: binary
+
+dockers:
+  - id: arm64 
+    goos: linux
+    goarch: arm64
+    dockerfile: Containerfile
+    image_templates: 
+      - ghcr.io/uor-framework/{{ .ProjectName }}:{{ .Tag }}-arm64
+    use: buildx
+    build_flag_templates:
+    - --platform=linux/arm64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.description={{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/uor-framework/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/uor-framework/{{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Tag }}
+    - --label=org.opencontainers.image.created={{ .Date }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=APACHE2.0
+  - id: amd64 
+    use: buildx
+    goos: linux
+    goarch: amd64
+    dockerfile: Containerfile
+    image_templates: 
+      - ghcr.io/uor-framework/{{ .ProjectName }}:{{ .Tag }}-amd64
+    build_flag_templates:
+    - --platform=linux/amd64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.description={{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/uor-framework/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/uor-framework/{{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Tag }}
+    - --label=org.opencontainers.image.created={{ .Date }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=APACHE2.0
+
+docker_manifests:
+  - name_template: ghcr.io/uor-framework/client:{{ .Tag }}
+    image_templates:
+      - ghcr.io/uor-framework/client:{{ .Tag }}-amd64
+      - ghcr.io/uor-framework/client:{{ .Tag }}-arm64
+  - name_template: ghcr.io/uor-framework/client:latest
+    image_templates:
+      - ghcr.io/uor-framework/client:{{ .Tag }}-amd64
+      - ghcr.io/uor-framework/client:{{ .Tag }}-arm64
+
+docker_signs:
+- cmd: cosign
+  artifacts: manifests
+  output: true
+  env:
+  - COSIGN_EXPERIMENTAL=1
+  args:
+  - 'sign'
+  - '${artifact}'
 
 checksum:
   name_template: 'checksums.txt'
@@ -41,18 +147,20 @@ changelog:
     - Merge branch
     - go mod tidy
 
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
 release:
-
-  prerelease: auto
-
+  draft: true
+  prerelease: allow
+  github:
+    owner: uor-framework
+    name: client
+  name_template: "{{.ProjectName}}-{{ .Tag }}"
   header: |
-    ## UOR Client ({{ .Date }})
 
-    Welcome to this new release!
+    ## UOR Client {{ .Version }}
 
   footer: |
-    ## Thanks!
 
-    Those were the changes on {{ .Tag }}!
-
-  name_template: "{{.ProjectName}}-v{{.Version}}"
+    ### Thank you to all contributors!

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,14 +84,14 @@ dockers:
     goarch: arm64
     dockerfile: Containerfile
     image_templates: 
-      - ghcr.io/uor-framework/{{ .ProjectName }}:{{ .Tag }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-arm64
     use: buildx
     build_flag_templates:
     - --platform=linux/arm64
     - --label=org.opencontainers.image.title={{ .ProjectName }}
     - --label=org.opencontainers.image.description={{ .ProjectName }}
-    - --label=org.opencontainers.image.url=https://github.com/uor-framework/{{ .ProjectName }}
-    - --label=org.opencontainers.image.source=https://github.com/uor-framework/{{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}
     - --label=org.opencontainers.image.version={{ .Tag }}
     - --label=org.opencontainers.image.created={{ .Date }}
     - --label=org.opencontainers.image.revision={{ .FullCommit }}
@@ -102,27 +102,27 @@ dockers:
     goarch: amd64
     dockerfile: Containerfile
     image_templates: 
-      - ghcr.io/uor-framework/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Tag }}-amd64
     build_flag_templates:
     - --platform=linux/amd64
     - --label=org.opencontainers.image.title={{ .ProjectName }}
     - --label=org.opencontainers.image.description={{ .ProjectName }}
-    - --label=org.opencontainers.image.url=https://github.com/uor-framework/{{ .ProjectName }}
-    - --label=org.opencontainers.image.source=https://github.com/uor-framework/{{ .ProjectName }}
+    - --label=org.opencontainers.image.url=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}
+    - --label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }}/{{ .ProjectName }}
     - --label=org.opencontainers.image.version={{ .Tag }}
     - --label=org.opencontainers.image.created={{ .Date }}
     - --label=org.opencontainers.image.revision={{ .FullCommit }}
     - --label=org.opencontainers.image.licenses=APACHE2.0
 
 docker_manifests:
-  - name_template: ghcr.io/uor-framework/client:{{ .Tag }}
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/client:{{ .Tag }}
     image_templates:
-      - ghcr.io/uor-framework/client:{{ .Tag }}-amd64
-      - ghcr.io/uor-framework/client:{{ .Tag }}-arm64
-  - name_template: ghcr.io/uor-framework/client:latest
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/client:{{ .Tag }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/client:{{ .Tag }}-arm64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/client:latest
     image_templates:
-      - ghcr.io/uor-framework/client:{{ .Tag }}-amd64
-      - ghcr.io/uor-framework/client:{{ .Tag }}-arm64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/client:{{ .Tag }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/client:{{ .Tag }}-arm64
 
 docker_signs:
 - cmd: cosign
@@ -154,7 +154,7 @@ release:
   draft: true
   prerelease: allow
   github:
-    owner: uor-framework
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: client
   name_template: "{{.ProjectName}}-{{ .Tag }}"
   header: |

--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,4 @@
+## Build a UBI micro rootfs from UBI repositories
 FROM registry.access.redhat.com/ubi9/ubi as builder
 
 ARG DNF_FLAGS="\
@@ -12,8 +13,8 @@ ARG DNF_PACKAGES="\
   coreutils-single \
   glibc-minimal-langpack \
 "
-
 ARG ROOTFS="/rootfs"
+
 RUN set -ex \
      && mkdir -p ${ROOTFS} \
      && dnf install ${DNF_FLAGS} ${ROOTFS} ${DNF_PACKAGES} \
@@ -21,14 +22,13 @@ RUN set -ex \
      && rm -rf ${ROOTFS}/var/cache/* \
     && echo
 
+## Build a container from UBI micro rootfs and load platform specific artifact
 FROM scratch
 COPY --from=builder /rootfs/ /
 
 ARG TARGETARCH
-COPY ./bin/client-linux-${TARGETARCH} /usr/local/bin/client
-RUN set -ex \
-     && /usr/local/bin/client version \
-    && echo
+COPY ../client-linux-${TARGETARCH} /usr/local/bin/client
+RUN set -ex && /usr/local/bin/client version
 
 ENTRYPOINT ["/usr/local/bin/client"]
 CMD ["version"]


### PR DESCRIPTION
closes #40 

Enhancing goreleaser.

On a new tagged release, goreleaser will build and publish the following:
  - [x] binaries:
    - [x] Linux:
      - [x] arm64
      - [x] amd64
      - [x] s390x
      - [x] ppc64le
    - [x] Darwin:
      - [x] arm64
      - [x] amd64
    - [x] Windows:
      - [x] amd64
  - [x] Containers:
    - [x] Linux:
      - [x] arm64
      - [x] amd64
  - [x] container signing
  - [x] SBOM
  - [x] Release notes