### PR TITLE
resolve linter warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           version: v1.46
           args: --timeout=5m
-          skip-go-installation: true
 
   #
   # Project checks


### PR DESCRIPTION
Remove invalid argument `skip-go-installation: true` to resolve linter action warnings.

closes #53 