### PR TITLE
chore: adds Example type for consistent CLI example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ uor-client-go version
 
 1. Create a directory with artifacts to publish to a registry as an OCI artifact. If the files reference each other, the client will replace the in-content linked files with the content address.
 > WARNING: Currently, only JSON is supported for link replacement.
-2. Use the `uor-client-go build` command to build the workspace as an OCI artifact in build-cache `default is (homedir/.uor/cache). Can be set with UOR_CACHE environment variable`.
+2. Use the `uor-client-go build` command to build the workspace as an OCI artifact in build-cache The default location is ~/.uor/cache. It an be set with the `UOR_CACHE` environment variable`.
 3. Use the `uor-client-go push` command to publish to a registry as an OCI artifact.
 4. Use the `uor-client-go pull` command to pull the artifact back to a local workspace.
 
 ### Build workspace into an artifact
 
 ```
-client build my-workspace localhost:5000/myartifacts:latest
+uor-client-go build my-workspace localhost:5000/myartifacts:latest
 ```
 
 ```
 # Optionally with dsconfig
-client build my-workspace localhost:5000/myartifacts:latest --dsconfig dataset-config.yaml
+uor-client-go build my-workspace localhost:5000/myartifacts:latest --dsconfig dataset-config.yaml
 ```
 ### Push workspace to a registry location
 
@@ -119,7 +119,7 @@ files:
 ```
 
 5. Run the UOR client build command referencing the dataset config, the content directory, and the destination registry location.
-   ```
+```
 uor-client-go build my-workspace localhost:5000/test/dataset:latest --dsconfig dataset-config.yaml 
 ```
 6. Run the UOR push command to publish

--- a/cli/build.go
+++ b/cli/build.go
@@ -5,17 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/uor-framework/uor-client-go/builder/api/v1alpha1"
 	load "github.com/uor-framework/uor-client-go/builder/config"
 	"github.com/uor-framework/uor-client-go/content/layout"
 	"github.com/uor-framework/uor-client-go/registryclient/orasclient"
+	"github.com/uor-framework/uor-client-go/util/examples"
 	"github.com/uor-framework/uor-client-go/util/workspace"
 )
 
@@ -28,12 +29,18 @@ type BuildOptions struct {
 	Destination string
 }
 
-var clientBuildExamples = templates.Examples(
-	`
-	# Build artifact
-	uor-client-go build my-directory localhost:5000/myartifacts:latest
-	`,
-)
+var clientBuildExamples = []examples.Example{
+	{
+		RootCommand:   filepath.Base(os.Args[0]),
+		Descriptions:  []string{"Build artifacts."},
+		CommandString: "build my-directory localhost:5000/myartifacts:latest",
+	},
+	{
+		RootCommand:   filepath.Base(os.Args[0]),
+		Descriptions:  []string{"Build artifacts with custom annotations."},
+		CommandString: "build my-directory localhost:5000/myartifacts:latest --dsconfig dataset-config.yaml",
+	},
+}
 
 // NewBuildCmd creates a new cobra.Command for the build subcommand.
 func NewBuildCmd(rootOpts *RootOptions) *cobra.Command {
@@ -42,7 +49,7 @@ func NewBuildCmd(rootOpts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "build SRC DST",
 		Short:         "Build and save an OCI artifact from files",
-		Example:       clientBuildExamples,
+		Example:       examples.FormatExamples(clientBuildExamples...),
 		SilenceErrors: false,
 		SilenceUsage:  false,
 		Args:          cobra.ExactArgs(2),

--- a/cli/pull.go
+++ b/cli/pull.go
@@ -11,7 +11,6 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/templates"
 	"oras.land/oras-go/v2/content/file"
 
 	"github.com/uor-framework/uor-client-go/attributes"
@@ -20,6 +19,7 @@ import (
 	"github.com/uor-framework/uor-client-go/model/nodes/basic"
 	"github.com/uor-framework/uor-client-go/model/nodes/collection"
 	"github.com/uor-framework/uor-client-go/registryclient/orasclient"
+	"github.com/uor-framework/uor-client-go/util/examples"
 	"github.com/uor-framework/uor-client-go/util/workspace"
 )
 
@@ -35,12 +35,11 @@ type PullOptions struct {
 	Attributes map[string]string
 }
 
-var clientPullExamples = templates.Examples(
-	`
-	# Push artifacts
-	client pull localhost:5000/myartifacts:latest
-	`,
-)
+var clientPullExamples = examples.Example{
+	RootCommand:   filepath.Base(os.Args[0]),
+	Descriptions:  []string{"Pull artifacts."},
+	CommandString: "pull localhost:5000/myartifacts:latest",
+}
 
 // NewPullCmd creates a new cobra.Command for the pull subcommand.
 func NewPullCmd(rootOpts *RootOptions) *cobra.Command {
@@ -49,7 +48,7 @@ func NewPullCmd(rootOpts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "pull SRC",
 		Short:         "Pull a UOR collection based on content or attribute address",
-		Example:       clientPullExamples,
+		Example:       examples.FormatExamples(clientPullExamples),
 		SilenceErrors: false,
 		SilenceUsage:  false,
 		Args:          cobra.ExactArgs(1),

--- a/cli/push.go
+++ b/cli/push.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/uor-framework/uor-client-go/content/layout"
 	"github.com/uor-framework/uor-client-go/registryclient/orasclient"
+	"github.com/uor-framework/uor-client-go/util/examples"
 )
 
 // PushOptions describe configuration options that can
@@ -23,12 +25,11 @@ type PushOptions struct {
 	DSConfig    string
 }
 
-var clientPushExamples = templates.Examples(
-	`
-	# Push artifacts
-	client push localhost:5000/myartifacts:latest
-	`,
-)
+var clientPushExamples = examples.Example{
+	RootCommand:   filepath.Base(os.Args[0]),
+	Descriptions:  []string{"Push artifacts."},
+	CommandString: "push localhost:5000/myartifacts:latest",
+}
 
 // NewPushCmd creates a new cobra.Command for the push subcommand.
 func NewPushCmd(rootOpts *RootOptions) *cobra.Command {
@@ -37,7 +38,7 @@ func NewPushCmd(rootOpts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "push DST",
 		Short:         "Push a UOR collection into a registry",
-		Example:       clientPushExamples,
+		Example:       examples.FormatExamples(clientPushExamples),
 		SilenceErrors: false,
 		SilenceUsage:  false,
 		Args:          cobra.ExactArgs(1),

--- a/cli/render.go
+++ b/cli/render.go
@@ -6,14 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/uor-framework/uor-client-go/builder"
 	"github.com/uor-framework/uor-client-go/builder/parser"
 	"github.com/uor-framework/uor-client-go/model/nodes/basic"
 	"github.com/uor-framework/uor-client-go/model/nodes/collection"
+	"github.com/uor-framework/uor-client-go/util/examples"
 	"github.com/uor-framework/uor-client-go/util/workspace"
 )
 
@@ -25,16 +26,21 @@ type RenderOptions struct {
 	Output  string
 }
 
-var clientRenderExamples = templates.Examples(
-	`
-	# Template content in a directory
-	# The default workspace is "client-workspace" in the current working directory.
-	client build my-directory
-
-	# Template content into a specified output directory.
-	client build my-directory --output my-workspace
-	`,
-)
+var clientRenderExamples = []examples.Example{
+	{
+		RootCommand:   filepath.Base(os.Args[0]),
+		CommandString: "render my-directory",
+		Descriptions: []string{
+			"Template content in a directory.",
+			"The default workspace is \"client-workspace\" in the current working directory.",
+		},
+	},
+	{
+		Descriptions:  []string{"Template content into a specified output directory."},
+		CommandString: "build my-directory --output my-workspace",
+		RootCommand:   filepath.Base(os.Args[0]),
+	},
+}
 
 // NewRenderCmd creates a new cobra.Command for the build subcommand.
 func NewRenderCmd(rootOpts *RootOptions) *cobra.Command {
@@ -45,7 +51,7 @@ func NewRenderCmd(rootOpts *RootOptions) *cobra.Command {
 		Hidden:        true,
 		Use:           "render SRC",
 		Short:         "Template and build files from a local directory into a UOR dataset",
-		Example:       clientRenderExamples,
+		Example:       examples.FormatExamples(clientRenderExamples...),
 		SilenceErrors: false,
 		SilenceUsage:  false,
 		Args:          cobra.ExactArgs(1),

--- a/cli/root.go
+++ b/cli/root.go
@@ -24,8 +24,8 @@ var clientLong = templates.LongDesc(
 	`
 	The UOR client helps you build, publish, and retrieve UOR collections as an OCI artifact.
 
-	The workflow to publish a collection is to to build gather files to for a collection in a 
-	directory workspace and use the build sub-command. During the build process with when the tag for the
+	The workflow to publish a collection is to gather files for a collection in a directory workspace 
+	and use the build sub-command. During the build process, the tag for the
 	remote destination is specified. 
 	
 	This build action will store the collection in a build cache. This location can be specified with the UOR_CACHE environment 
@@ -33,7 +33,7 @@ var clientLong = templates.LongDesc(
 	
 	After the collection has been stored, it can be retrieved and pushed the to registry with the push sub-command.
 
-	Collections can be retrieved from the cache or the remote location (if not stored) will the pull command. The pull sub-command also
+	Collections can be retrieved from the cache or the remote location (if not stored) with the pull sub-command. The pull sub-command also
 	allows for filtering of the collection with the attributes flag.
 	`,
 )

--- a/cli/root.go
+++ b/cli/root.go
@@ -22,7 +22,19 @@ type RootOptions struct {
 
 var clientLong = templates.LongDesc(
 	`
-	This client helps you build and publish UOR collections as an OCI artifact.
+	The UOR client helps you build, publish, and retrieve UOR collections as an OCI artifact.
+
+	The workflow to publish a collection is to to build gather files to for a collection in a 
+	directory workspace and use the build sub-command. During the build process with when the tag for the
+	remote destination is specified. 
+	
+	This build action will store the collection in a build cache. This location can be specified with the UOR_CACHE environment 
+	variable. The default location is ~/.uor/cache. 
+	
+	After the collection has been stored, it can be retrieved and pushed the to registry with the push sub-command.
+
+	Collections can be retrieved from the cache or the remote location (if not stored) will the pull command. The pull sub-command also
+	allows for filtering of the collection with the attributes flag.
 	`,
 )
 

--- a/util/examples/examples.go
+++ b/util/examples/examples.go
@@ -1,0 +1,37 @@
+package examples
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+// Examples defines fields required to construct
+// a CLI command example
+type Example struct {
+	Descriptions  []string
+	RootCommand   string
+	CommandString string
+}
+
+// String renders a formatted example.
+func (e *Example) String() string {
+	description := new(strings.Builder)
+	for _, d := range e.Descriptions {
+		description.WriteString("# ")
+		description.WriteString(d)
+		description.WriteString("\n")
+	}
+	return fmt.Sprintf("%s %s %s", description, e.RootCommand, e.CommandString)
+}
+
+// FormatExamples formats one or more Example instances.
+func FormatExamples(examples ...Example) string {
+	allExamples := new(strings.Builder)
+	for _, e := range examples {
+		allExamples.WriteString(e.String())
+		allExamples.WriteString("\n\n")
+	}
+	return templates.Examples(allExamples.String())
+}

--- a/util/examples/examples_test.go
+++ b/util/examples/examples_test.go
@@ -1,0 +1,69 @@
+package examples
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatExamples(t *testing.T) {
+	type spec struct {
+		name     string
+		examples []Example
+		expRes   string
+	}
+
+	cases := []spec{
+		{
+			name: "Success/NoExamples",
+		},
+		{
+			name: "Success/OneExample",
+			examples: []Example{
+				{
+					RootCommand:   "test",
+					CommandString: "subcommand",
+					Descriptions:  []string{"This is a test."},
+				},
+			},
+			expRes: "  # This is a test.\n  test subcommand",
+		},
+		{
+			name: "Success/OneExampleMultipleDescriptionLines",
+			examples: []Example{
+				{
+					RootCommand:   "test",
+					CommandString: "subcommand",
+					Descriptions: []string{
+						"This is a test.",
+						"The default is false",
+					},
+				},
+			},
+			expRes: "  # This is a test.\n  # The default is false\n  test subcommand",
+		},
+		{
+			name: "Success/TwoExamples",
+			examples: []Example{
+				{
+					RootCommand:   "test",
+					CommandString: "subcommand",
+					Descriptions:  []string{"This is a test."},
+				},
+				{
+					RootCommand:   "test",
+					CommandString: "subcommand --flag",
+					Descriptions:  []string{"This is a test with a flag."},
+				},
+			},
+			expRes: "  # This is a test.\n  test subcommand\n  \n  # This is a test with a flag.\n  test subcommand --flag",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expRes, FormatExamples(c.examples...))
+		})
+	}
+
+}


### PR DESCRIPTION
- Adds a solution to allow for consistent example formatting with dynamic content for multiple build environments.
- Updates the Long Description on the root command
- Fixes formatting in Readme.md

- [X] Tests Added
- [ ] Getting Started updates required

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>