### PR TITLE
refactor: configures registry client auth during client creation

### DIFF
--- a/registryclient/orasclient/options.go
+++ b/registryclient/orasclient/options.go
@@ -2,9 +2,12 @@ package orasclient
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 	"sync"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
@@ -56,13 +59,30 @@ func NewClient(options ...ClientOption) (registryclient.Client, error) {
 		return
 	}
 
-	client.insecure = config.insecure
-	client.configs = config.configs
 	client.plainHTTP = config.plainHTTP
 	client.copyOpts = config.copyOpts
 	client.outputDir = config.outputDir
 	client.destroy = destroy
 	client.cache = config.cache
+
+	// Setup auth client based on config inputs
+	authClient := &auth.Client{
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: config.insecure,
+				},
+			},
+		},
+		Cache: auth.NewCache(),
+	}
+
+	store, err := NewAuthStore(config.configs...)
+	if err != nil {
+		return nil, err
+	}
+	authClient.Credential = store.Credential
+	client.authClient = authClient
 
 	// We are not allowing this to be configurable since
 	// `oras` file store turn artifacts into descriptors in


### PR DESCRIPTION
A new repository is created each time a remote method is called because
the source reference may not be in the same repository each call. Currently, the
authentication client is being recreated on these calls as well, but this is
not required so this change creates the authentication client during registry
client instantiation.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>