### PR TITLE
Adds logrus GRPC logging interceptors

### DIFF
--- a/cmd/client/commands/build_collection_test.go
+++ b/cmd/client/commands/build_collection_test.go
@@ -101,7 +101,7 @@ func TestBuildCollectionValidate(t *testing.T) {
 }
 
 func TestBuildCollectionRun(t *testing.T) {
-	testlogr, err := log.NewLogger(ioutil.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(ioutil.Discard, "debug")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(registry.New())

--- a/cmd/client/commands/build_schema_test.go
+++ b/cmd/client/commands/build_schema_test.go
@@ -95,7 +95,7 @@ func TestBuildSchemaValidate(t *testing.T) {
 }
 
 func TestBuildSchemaRun(t *testing.T) {
-	testlogr, err := log.NewLogger(ioutil.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(ioutil.Discard, "debug")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(registry.New())

--- a/cmd/client/commands/cli_e2e_test.go
+++ b/cmd/client/commands/cli_e2e_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestCLIE2E(t *testing.T) {
-	testlogr, err := log.NewLogger(ioutil.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(ioutil.Discard, "debug")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(registry.New())

--- a/cmd/client/commands/inspect_test.go
+++ b/cmd/client/commands/inspect_test.go
@@ -67,7 +67,7 @@ func TestInspectValidate(t *testing.T) {
 }
 
 func TestInspectRun(t *testing.T) {
-	testlogr, err := log.NewLogger(ioutil.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(ioutil.Discard, "debug")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(registry.New())

--- a/cmd/client/commands/options/common.go
+++ b/cmd/client/commands/options/common.go
@@ -21,7 +21,7 @@ type EnvConfig struct {
 type Common struct {
 	IOStreams genericclioptions.IOStreams
 	LogLevel  string
-	Logger    log.Logger
+	Logger    log.LoggerWithInterceptor
 	CacheDir  string
 	EnvConfig
 }
@@ -34,7 +34,7 @@ func (o *Common) BindFlags(fs *pflag.FlagSet) {
 
 // Init initializes default values for Common options.
 func (o *Common) Init() error {
-	logger, err := log.NewLogger(o.IOStreams.Out, o.LogLevel)
+	logger, err := log.NewLogrusLogger(o.IOStreams.Out, o.LogLevel)
 	if err != nil {
 		return err
 	}

--- a/cmd/client/commands/pull_test.go
+++ b/cmd/client/commands/pull_test.go
@@ -104,7 +104,7 @@ func TestPullValidate(t *testing.T) {
 }
 
 func TestPullRun(t *testing.T) {
-	testlogr, err := log.NewLogger(io.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(io.Discard, "debug")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(registry.New())

--- a/cmd/client/commands/push_test.go
+++ b/cmd/client/commands/push_test.go
@@ -59,7 +59,7 @@ func TestPushComplete(t *testing.T) {
 }
 
 func TestPushRun(t *testing.T) {
-	testlogr, err := log.NewLogger(ioutil.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(ioutil.Discard, "debug")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(registry.New())

--- a/cmd/client/commands/serve.go
+++ b/cmd/client/commands/serve.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"syscall"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
@@ -74,7 +75,8 @@ func (o *ServeOptions) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	rpc := grpc.NewServer()
+	interceptors := o.Logger.WithServerInterceptors()
+	rpc := grpc.NewServer(grpc_middleware.WithUnaryServerChain(interceptors...))
 
 	cache, err := layout.NewWithContext(ctx, o.CacheDir)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-containerregistry v0.11.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
@@ -146,7 +148,6 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 // indirect
@@ -172,7 +173,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect

--- a/log/log.go
+++ b/log/log.go
@@ -3,7 +3,10 @@ package log
 import (
 	"io"
 
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 )
 
 // Logger is an interface the defines logging methods.
@@ -15,18 +18,27 @@ type Logger interface {
 	Fatalf(string, ...interface{})
 }
 
-type standardLogger struct {
-	logger *logrus.Logger
+// LoggerWithInterceptor is an interface that uses a logging interface
+// and configures unary server interceptors for
+// gRPC logging.
+type LoggerWithInterceptor interface {
+	Logger
+	WithServerInterceptors() []grpc.UnaryServerInterceptor
 }
 
-// NewLogger returns a new Logger.
-func NewLogger(out io.Writer, level string) (Logger, error) {
+// LogrusLogger is a wrapper for Logrus to implement the Logger interface.
+type LogrusLogger struct {
+	Logger *logrus.Logger
+}
+
+// NewLogrusLogger creates a new LogrusLogger with the given inputs.
+func NewLogrusLogger(out io.Writer, level string) (*LogrusLogger, error) {
 	lvl, err := logrus.ParseLevel(level)
 	if err != nil {
 		return nil, err
 	}
-	slogr := &standardLogger{
-		logger: &logrus.Logger{
+	slogr := &LogrusLogger{
+		Logger: &logrus.Logger{
 			Out:       out,
 			Formatter: new(logrus.TextFormatter),
 			Hooks:     make(logrus.LevelHooks),
@@ -37,22 +49,37 @@ func NewLogger(out io.Writer, level string) (Logger, error) {
 	return slogr, nil
 }
 
-func (l *standardLogger) Errorf(format string, args ...interface{}) {
-	l.logger.Logf(logrus.ErrorLevel, format, args...)
+func (l *LogrusLogger) Errorf(format string, args ...interface{}) {
+	l.Logger.Logf(logrus.ErrorLevel, format, args...)
 }
 
-func (l *standardLogger) Infof(format string, args ...interface{}) {
-	l.logger.Logf(logrus.InfoLevel, format, args...)
+func (l *LogrusLogger) Infof(format string, args ...interface{}) {
+	l.Logger.Logf(logrus.InfoLevel, format, args...)
 }
 
-func (l *standardLogger) Warnf(format string, args ...interface{}) {
-	l.logger.Logf(logrus.WarnLevel, format, args...)
+func (l *LogrusLogger) Warnf(format string, args ...interface{}) {
+	l.Logger.Logf(logrus.WarnLevel, format, args...)
 }
 
-func (l *standardLogger) Debugf(format string, args ...interface{}) {
-	l.logger.Logf(logrus.DebugLevel, format, args...)
+func (l *LogrusLogger) Debugf(format string, args ...interface{}) {
+	l.Logger.Logf(logrus.DebugLevel, format, args...)
 }
 
-func (l *standardLogger) Fatalf(format string, args ...interface{}) {
-	l.logger.Logf(logrus.FatalLevel, format, args...)
+func (l *LogrusLogger) Fatalf(format string, args ...interface{}) {
+	l.Logger.Logf(logrus.FatalLevel, format, args...)
+}
+
+func (l *LogrusLogger) WithServerInterceptors() []grpc.UnaryServerInterceptor {
+	// Logrus entry is used, allowing pre-definition of certain fields by the user.
+	logrusEntry := logrus.NewEntry(l.Logger)
+	// Shared options for the logger, with a custom gRPC code to log level function.
+	opts := []grpc_logrus.Option{
+		grpc_logrus.WithLevels(grpc_logrus.DefaultCodeToLevel),
+	}
+	// Make sure that log statements internal to gRPC library are logged using the logrus Logger as well.
+	grpc_logrus.ReplaceGrpcLogger(logrusEntry)
+	return []grpc.UnaryServerInterceptor{
+		grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+		grpc_logrus.UnaryServerInterceptor(logrusEntry, opts...),
+	}
 }

--- a/services/collectionmanager/service_test.go
+++ b/services/collectionmanager/service_test.go
@@ -106,7 +106,7 @@ func TestCollectionManagerServer_All(t *testing.T) {
 
 	ctx := context.Background()
 
-	testlogr, err := log.NewLogger(ioutil.Discard, "debug")
+	testlogr, err := log.NewLogrusLogger(ioutil.Discard, "debug")
 	require.NoError(t, err)
 
 	manager := defaultmanager.New(testContentStore{Store: memory.New()}, testlogr)


### PR DESCRIPTION
# Description

Adds gRPC server interceptors for `logrus` to get better logging output for `uor-client-go` serve.


## Type of change

<!--Please delete options that are not relevant.-->

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested

## How to test

```
uor-client-go serve test.sock

# https://github.com/uor-community/sample-client-go (main)

sample-client push test localhost:5001/test:latest -s  /tmp/test.sock 
sample-client pull localhost:5001/test:latest -s  /tmp/test.sock 
```

Test with go sample client
### Acceptance criteria
gRPC logs can be viewed from the terminal instantiated the server process.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Requires updates to the [Getting Started Guide](https://universalreference.io/docs/quick-start/)