### PR TITLE
Adds pre pull function option to orasclient

### DIFF
--- a/cmd/client/commands/build_collection_test.go
+++ b/cmd/client/commands/build_collection_test.go
@@ -173,6 +173,7 @@ func TestBuildCollectionRun(t *testing.T) {
 				Remote: options.Remote{
 					PlainHTTP: true,
 				},
+				NoVerify: true,
 			},
 		},
 		{
@@ -194,6 +195,7 @@ func TestBuildCollectionRun(t *testing.T) {
 				Remote: options.Remote{
 					PlainHTTP: true,
 				},
+				NoVerify: true,
 			},
 		},
 		{
@@ -237,6 +239,7 @@ func TestBuildCollectionRun(t *testing.T) {
 				Remote: options.Remote{
 					PlainHTTP: true,
 				},
+				NoVerify: true,
 			},
 			expError: fmt.Sprintf("reference %s/test:latest is not a schema address", u.Host),
 		},

--- a/cmd/client/commands/pull.go
+++ b/cmd/client/commands/pull.go
@@ -76,6 +76,7 @@ func NewPullCmd(common *options.Common) *cobra.Command {
 
 	o.Remote.BindFlags(cmd.Flags())
 	o.RemoteAuth.BindFlags(cmd.Flags())
+
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "output location for artifacts")
 	cmd.Flags().StringVar(&o.AttributeQuery, "attributes", o.AttributeQuery, "attribute query config path")
 	cmd.Flags().BoolVar(&o.PullAll, "pull-all", o.PullAll, "pull all linked collections")
@@ -106,14 +107,6 @@ func (o *PullOptions) Validate() error {
 
 func (o *PullOptions) Run(ctx context.Context) error {
 
-	if !o.NoVerify {
-		o.Logger.Infof("Checking signature of %s", o.Source)
-		if err := verifyCollection(ctx, o.Source, o.RemoteAuth.Configs, o.Remote); err != nil {
-			return err
-		}
-
-	}
-
 	matcher := matchers.PartialAttributeMatcher{}
 	if o.AttributeQuery != "" {
 		query, err := config.ReadAttributeQuery(o.AttributeQuery)
@@ -133,13 +126,27 @@ func (o *PullOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	client, err := orasclient.NewClient(
+	var clientOpts = []orasclient.ClientOption{
 		orasclient.SkipTLSVerify(o.Insecure),
 		orasclient.WithAuthConfigs(o.Configs),
 		orasclient.WithPlainHTTP(o.PlainHTTP),
 		orasclient.WithCache(cache),
 		orasclient.WithPullableAttributes(matcher),
-	)
+	}
+
+	if !o.NoVerify {
+		verificationFn := func(ctx context.Context, reference string) error {
+			o.Logger.Infof("Checking signature of %s", o.Source)
+			err = verifyCollection(ctx, reference, o.RemoteAuth.Configs, o.Remote)
+			if err != nil {
+				return fmt.Errorf("collection %q: %v", reference, err)
+			}
+			return nil
+		}
+		clientOpts = append(clientOpts, orasclient.WithPrePull(verificationFn))
+	}
+
+	client, err := orasclient.NewClient(clientOpts...)
 	if err != nil {
 		return fmt.Errorf("error configuring client: %v", err)
 	}

--- a/cmd/client/commands/pull.go
+++ b/cmd/client/commands/pull.go
@@ -80,7 +80,7 @@ func NewPullCmd(common *options.Common) *cobra.Command {
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "output location for artifacts")
 	cmd.Flags().StringVar(&o.AttributeQuery, "attributes", o.AttributeQuery, "attribute query config path")
 	cmd.Flags().BoolVar(&o.PullAll, "pull-all", o.PullAll, "pull all linked collections")
-	cmd.Flags().BoolVarP(&o.NoVerify, "no-verify", "", o.NoVerify, "skip collection signature verification")
+	cmd.Flags().BoolVar(&o.NoVerify, "no-verify", o.NoVerify, "skip collection signature verification")
 
 	return cmd
 }
@@ -136,14 +136,14 @@ func (o *PullOptions) Run(ctx context.Context) error {
 
 	if !o.NoVerify {
 		verificationFn := func(ctx context.Context, reference string) error {
-			o.Logger.Infof("Checking signature of %s", o.Source)
+			o.Logger.Debugf("Checking signature of %s", reference)
 			err = verifyCollection(ctx, reference, o.RemoteAuth.Configs, o.Remote)
 			if err != nil {
 				return fmt.Errorf("collection %q: %v", reference, err)
 			}
 			return nil
 		}
-		clientOpts = append(clientOpts, orasclient.WithPrePull(verificationFn))
+		clientOpts = append(clientOpts, orasclient.WithPrePullFunc(verificationFn))
 	}
 
 	client, err := orasclient.NewClient(clientOpts...)

--- a/cmd/client/commands/push.go
+++ b/cmd/client/commands/push.go
@@ -53,7 +53,7 @@ func NewPushCmd(common *options.Common) *cobra.Command {
 	o.Remote.BindFlags(cmd.Flags())
 	o.RemoteAuth.BindFlags(cmd.Flags())
 
-	cmd.Flags().BoolVarP(&o.Sign, "sign", "", o.Sign, "keyless OIDC signing of UOR Collections with Sigstore")
+	cmd.Flags().BoolVarP(&o.Sign, "sign", "s", o.Sign, "keyless OIDC signing of UOR Collections with Sigstore")
 
 	return cmd
 }

--- a/manager/defaultmanager/build.go
+++ b/manager/defaultmanager/build.go
@@ -58,13 +58,10 @@ func (d DefaultManager) Build(ctx context.Context, space workspace.Workspace, co
 	if config.Collection.SchemaAddress != "" {
 		d.logger.Infof("Validating dataset configuration against schema %s", config.Collection.SchemaAddress)
 		collectionManifestAnnotations[ocimanifest.AnnotationSchema] = config.Collection.SchemaAddress
-		if err != nil {
-			return "", fmt.Errorf("error configuring client: %v", err)
-		}
 
 		_, _, err = client.Pull(ctx, config.Collection.SchemaAddress, d.store)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("error configuring client: %v", err)
 		}
 
 		schemaDoc, err := fetchJSONSchema(ctx, config.Collection.SchemaAddress, d.store)

--- a/registryclient/orasclient/options.go
+++ b/registryclient/orasclient/options.go
@@ -24,7 +24,6 @@ type ClientOption func(o *ClientConfig) error
 
 // ClientConfig contains configuration data for the registry client.
 type ClientConfig struct {
-	outputDir  string
 	configs    []string
 	credFn     func(context.Context, string) (auth.Credential, error)
 	prePullFn  func(context.Context, string) error
@@ -88,7 +87,6 @@ func NewClient(options ...ClientOption) (registryclient.Client, error) {
 	client.authClient = authClient
 	client.plainHTTP = config.plainHTTP
 	client.copyOpts = config.copyOpts
-	client.outputDir = config.outputDir
 	client.destroy = destroy
 	client.cache = config.cache
 	client.attributes = config.attributes
@@ -107,14 +105,6 @@ func NewClient(options ...ClientOption) (registryclient.Client, error) {
 func WithCredentialFunc(credFn func(context.Context, string) (auth.Credential, error)) ClientOption {
 	return func(config *ClientConfig) error {
 		config.credFn = credFn
-		return nil
-	}
-}
-
-// WithPrePull applies a function to a reference before copying it.
-func WithPrePull(prePullFn func(context.Context, string) error) ClientOption {
-	return func(config *ClientConfig) error {
-		config.prePullFn = prePullFn
 		return nil
 	}
 }
@@ -150,6 +140,15 @@ func WithPlainHTTP(plainHTTP bool) ClientOption {
 func WithCache(store content.Store) ClientOption {
 	return func(config *ClientConfig) error {
 		config.cache = store
+		return nil
+	}
+}
+
+// WithPrePullFunc applies a function to a reference before pulling it to a content
+// store.
+func WithPrePullFunc(prePullFn func(context.Context, string) error) ClientOption {
+	return func(config *ClientConfig) error {
+		config.prePullFn = prePullFn
 		return nil
 	}
 }

--- a/registryclient/orasclient/oras.go
+++ b/registryclient/orasclient/oras.go
@@ -30,17 +30,22 @@ import (
 )
 
 type orasClient struct {
-	plainHTTP     bool
-	authClient    *auth.Client
-	copyOpts      oras.CopyOptions
-	prePullFn     func(context.Context, string) error
+	plainHTTP  bool
+	authClient *auth.Client
+	// oras-specific copy options
+	copyOpts oras.CopyOptions
+	// User specified pre-pull actions
+	// (e.g. signature verification).
+	prePullFn func(context.Context, string) error
+	// underlying store for collection
+	// building on disk
 	artifactStore *file.Store
-	cache         content.Store
+	// Location of cached blobs
+	cache content.Store
 	// collection will store a cache of
 	// loaded collections from remote sources.
 	collections sync.Map // map[string]collection.Collection
 	destroy     func() error
-	outputDir   string
 	// attributes is set to filter
 	// collections by attribute.
 	attributes model.Matcher

--- a/registryclient/orasclient/oras_test.go
+++ b/registryclient/orasclient/oras_test.go
@@ -2,6 +2,7 @@ package orasclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -111,7 +112,7 @@ func TestPushPull(t *testing.T) {
 
 	ctx := context.TODO()
 
-	t.Run("Success/PushOneImage", func(t *testing.T) {
+	t.Run("Success/PushOneCollection", func(t *testing.T) {
 		cache := memory.New()
 		expDigest := "sha256:98f36e12e9dbacfbb10b9d1f32a46641eb42de588e54cfd7e8627d950ae8140a"
 		c, err := NewClient(WithPlainHTTP(true), WithCache(cache))
@@ -133,7 +134,7 @@ func TestPushPull(t *testing.T) {
 		require.NoError(t, c.Destroy())
 	})
 
-	t.Run("Success/PullOneImage", func(t *testing.T) {
+	t.Run("Success/PullOneCollection", func(t *testing.T) {
 		expDigest := "sha256:98f36e12e9dbacfbb10b9d1f32a46641eb42de588e54cfd7e8627d950ae8140a"
 		c, err := NewClient(WithPlainHTTP(true))
 		require.NoError(t, err)
@@ -144,7 +145,24 @@ func TestPushPull(t *testing.T) {
 		require.NoError(t, c.Destroy())
 	})
 
-	t.Run("Success/FilteredImage", func(t *testing.T) {
+	t.Run("Success/PullWithPrePull", func(t *testing.T) {
+		expDigest := "sha256:98f36e12e9dbacfbb10b9d1f32a46641eb42de588e54cfd7e8627d950ae8140a"
+		var testRef []string
+		prePullFn := func(ctx context.Context, reference string) error {
+			testRef = append(testRef, reference)
+			return nil
+		}
+		c, err := NewClient(WithPlainHTTP(true), WithPrePullFunc(prePullFn))
+		require.NoError(t, err)
+		root, descs, err := c.Pull(context.TODO(), ref, memory.New())
+		require.NoError(t, err)
+		require.Equal(t, expDigest, root.Digest.String())
+		require.Len(t, descs, 4)
+		require.Equal(t, []string{ref}, testRef)
+		require.NoError(t, c.Destroy())
+	})
+
+	t.Run("Success/PullFilteredCollection", func(t *testing.T) {
 		expDigest := ""
 		matcher := matchers.PartialAttributeMatcher{"test": attributes.NewString("test", "fail")}
 		c, err := NewClient(WithPlainHTTP(true), WithPullableAttributes(matcher))
@@ -168,7 +186,7 @@ func TestPushPull(t *testing.T) {
 		require.NoError(t, c.Destroy())
 	})
 
-	t.Run("Success/PushMultipleImages", func(t *testing.T) {
+	t.Run("Success/PushMultipleCollections", func(t *testing.T) {
 		c, err := NewClient(WithPlainHTTP(true))
 		require.NoError(t, err)
 		descs, err := c.AddFiles(ctx, "", testdata)
@@ -189,7 +207,7 @@ func TestPushPull(t *testing.T) {
 		require.NoError(t, c.Destroy())
 	})
 
-	t.Run("Success/PullMultipleImages", func(t *testing.T) {
+	t.Run("Success/PullMultipleCollections", func(t *testing.T) {
 		tmp := t.TempDir()
 		destination := file.New(tmp)
 		c, err := NewClient(WithPlainHTTP(true))
@@ -208,6 +226,17 @@ func TestPushPull(t *testing.T) {
 		require.NoError(t, err)
 		_, _, err = c.Pull(context.TODO(), notExistRef, memory.New())
 		require.EqualError(t, err, fmt.Sprintf("%s: not found", notExistTag))
+		require.NoError(t, c.Destroy())
+	})
+
+	t.Run("Failure/PrePullFail", func(t *testing.T) {
+		prePullFn := func(ctx context.Context, reference string) error {
+			return errors.New("I failed")
+		}
+		c, err := NewClient(WithPlainHTTP(true), WithPrePullFunc(prePullFn))
+		require.NoError(t, err)
+		_, _, err = c.Pull(context.TODO(), ref, memory.New())
+		require.EqualError(t, err, "I failed")
 		require.NoError(t, c.Destroy())
 	})
 }

--- a/services/collectionmanager/service.go
+++ b/services/collectionmanager/service.go
@@ -26,7 +26,7 @@ type service struct {
 	options ServiceOptions
 }
 
-// ServiceOptions configure the collection router service with default remote
+// ServiceOptions configure the collection manager service with default remote
 // and collection caching options.
 type ServiceOptions struct {
 	Insecure  bool


### PR DESCRIPTION
# Description

This PR adds an option to the `orasclient` that allows a caller to specify a pre-pull function. This is useful when passing a configured client to function that executes a high-level workflow like `defaultmanager.PullAll` or `defaultmanager.Build` that requires collection pulling.

This changes signature verification by default for all source and linked collections and schemas.

Fixes #104 

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Create a schema-configuration file to define attribute keys and types for corresponding collections:   
   ```bash
    kind: SchemaConfiguration
    apiVersion: client.uor-framework.io/v1alpha1
    schema:
      attributeTypes:
        "animal": string
        "size": string
        "color": string
        "habitat": string
        "mammal": boolean
   ```
2. Build and save the schema:
    ```
    uor-client-go build schema schema-config.yaml localhost:5000/myschema:latest
    ```
3. Push the schema to the remote registry with no signature:
   ```
   uor-client-go push localhost:5000/myschema:latest
   ```
4. Create a new directory.
5. Add the content to be uploaded in the directory (can be files of any content types).
6. Create a dataset-config.yaml
    ```bash
    kind: DataSetConfiguration
    apiVersion: client.uor-framework.io/v1alpha1
    collection:
      schemaAddress: "localhost:5000/myschema:latest"
      files:
        - file: "fish.jpg"
          attributes:
            animal: "fish"
            habitat: "ocean"
            size: "small"
            color: "blue"
            mammal: false
        - file: "subdir1/dog.jpg"
          attributes:
            animal: "dog"
            habitat: "house"
            size: "medium"
            color: "brown"
            mammal: true
    ```
7. Build the collection
    ```
    uor-client-go build collection my-workspace localhost:5000/test/dataset:latest --dsconfig dataset-config.yaml 
    ... no matching signatures
    ```
8. Build the Collection again with no verify
    ```
    uor-client-go build collection my-workspace localhost:5000/test/dataset:latest --dsconfig dataset-config.yaml --no-verify
    ```
9. Repush schema and sign
      ```
       uor-client-go push localhost:5000/myschema:latest --sign
      ```
10. Rebuild the collection
       ```
      uor-client-go build collection my-workspace localhost:5000/test/dataset:latest --dsconfig dataset-config.yaml
      ```


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Requires updates to the [Getting Started Guide](https://universalreference.io/docs/quick-start/)