### PR TITLE
fix: fixes logic during collection loading for index manifest processing

### DIFF
--- a/nodes/collection/loader/manifest_to_collection.go
+++ b/nodes/collection/loader/manifest_to_collection.go
@@ -28,9 +28,10 @@ func LoadFromManifest(ctx context.Context, graph *collection.Collection, fetcher
 	// track content status
 	tracker := traversal.NewTracker(root, nil)
 
+	seen := map[string]struct{}{}
 	handler := traversal.HandlerFunc(func(ctx context.Context, tracker traversal.Tracker, node model.Node) ([]model.Node, error) {
 		// skip the node if it has been indexed
-		if graph.HasNode(node.ID()) {
+		if _, ok := seen[node.ID()]; ok {
 			return nil, traversal.ErrSkip
 		}
 
@@ -39,7 +40,7 @@ func LoadFromManifest(ctx context.Context, graph *collection.Collection, fetcher
 			return nil, traversal.ErrSkip
 		}
 
-		successors, err := getSuccessors(ctx, fetcher, manifest)
+		successors, err := getSuccessors(ctx, fetcher, desc.Descriptor())
 		if err != nil {
 			return nil, err
 		}
@@ -48,6 +49,8 @@ func LoadFromManifest(ctx context.Context, graph *collection.Collection, fetcher
 		if err != nil {
 			return nil, err
 		}
+
+		seen[node.ID()] = struct{}{}
 
 		return nodes, nil
 	})

--- a/nodes/collection/loader/manifest_to_collection_test.go
+++ b/nodes/collection/loader/manifest_to_collection_test.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -13,29 +14,59 @@ import (
 )
 
 func TestLoadFromManifest(t *testing.T) {
-	expIDs := []string{
-		"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
-		"sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5",
-		"sha256:0c7f453f9f3463d41110402f70e913ef7d850986a231276c0065ff958639b976",
-		"sha256:2e30f6131ce2164ed5ef017845130727291417d60a1be6fad669bdc4473289cd",
-		"sha256:5c29ebcf4a3e7ac6dca6dcea98b4fa98de57c4aca65fa0b49989fbeab1dfdf84",
-		"sha256:684853a5c4538a93eaee331454bdf152be9d4a54fee9be3121594adac335a3ab",
-	}
-	root := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Digest:    digest.Digest("sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5"),
-	}
 
-	graph := collection.New("test")
-	err := LoadFromManifest(context.Background(), graph, testFetcher, root)
-	require.NoError(t, err)
-	var ids []string
-	for _, node := range graph.Nodes() {
-		ids = append(ids, node.ID())
-	}
-	sortIDS(ids)
-	sortIDS(expIDs)
-	require.Equal(t, expIDs, ids)
+	t.Run("Success/ImageManifest", func(t *testing.T) {
+		expIDs := []string{
+			"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+			"sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5",
+			"sha256:0c7f453f9f3463d41110402f70e913ef7d850986a231276c0065ff958639b976",
+			"sha256:2e30f6131ce2164ed5ef017845130727291417d60a1be6fad669bdc4473289cd",
+			"sha256:5c29ebcf4a3e7ac6dca6dcea98b4fa98de57c4aca65fa0b49989fbeab1dfdf84",
+			"sha256:684853a5c4538a93eaee331454bdf152be9d4a54fee9be3121594adac335a3ab",
+		}
+		root := ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Digest:    digest.Digest("sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5"),
+		}
+
+		graph := collection.New("test")
+		err := LoadFromManifest(context.Background(), graph, testFetcher, root)
+		require.NoError(t, err)
+		var ids []string
+		for _, node := range graph.Nodes() {
+			ids = append(ids, node.ID())
+		}
+		sortIDS(ids)
+		sortIDS(expIDs)
+		require.Equal(t, expIDs, ids)
+	})
+
+	t.Run("Success/IndexManifest", func(t *testing.T) {
+		expIDs := []string{
+			"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+			"sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5",
+			"sha256:0c7f453f9f3463d41110402f70e913ef7d850986a231276c0065ff958639b976",
+			"sha256:2e30f6131ce2164ed5ef017845130727291417d60a1be6fad669bdc4473289cd",
+			"sha256:5c29ebcf4a3e7ac6dca6dcea98b4fa98de57c4aca65fa0b49989fbeab1dfdf84",
+			"sha256:684853a5c4538a93eaee331454bdf152be9d4a54fee9be3121594adac335a3ab",
+			"sha256:d2848f7ab57ec3570ea6f7086b1a923751633e15f123126e1de1a67b19f59424",
+		}
+		root := ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageIndex,
+			Digest:    digest.Digest("sha256:d2848f7ab57ec3570ea6f7086b1a923751633e15f123126e1de1a67b19f59424"),
+		}
+
+		graph := collection.New("test")
+		err := LoadFromManifest(context.Background(), graph, testFetcher, root)
+		require.NoError(t, err)
+		var ids []string
+		for _, node := range graph.Nodes() {
+			ids = append(ids, node.ID())
+		}
+		sortIDS(ids)
+		sortIDS(expIDs)
+		require.Equal(t, expIDs, ids)
+	})
 }
 
 func sortIDS(ids []string) {
@@ -45,6 +76,20 @@ func sortIDS(ids []string) {
 }
 
 func testFetcher(_ context.Context, desc ocispec.Descriptor) ([]byte, error) {
+	i := `{
+"schemaVersion": 2,
+"mediaType": "application/vnd.oci.image.index.v1+json",
+"manifests": [
+{
+"mediaType": "application/vnd.oci.image.manifest.v1+json",
+"digest": "sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5",
+"size": 1355
+}
+]
+}
+`
+	d := digest.FromString(i)
+	fmt.Println(d.String())
 	s := `{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -92,8 +137,12 @@ func testFetcher(_ context.Context, desc ocispec.Descriptor) ([]byte, error) {
   }
 }
 `
-	if desc.Digest.String() == "sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5" {
+	switch desc.Digest.String() {
+	case "sha256:d2848f7ab57ec3570ea6f7086b1a923751633e15f123126e1de1a67b19f59424":
+		return []byte(i), nil
+	case "sha256:5410e32d6fdd0b638ae95c0c88326a6afe62105f2db1505ded397d2074dcbeb5":
 		return []byte(s), nil
 	}
+
 	return []byte{}, nil
 }


### PR DESCRIPTION
# Description

This change is a fix for a bug that keeps index manifests from being fully traversed during collection loading. Since collections are published as image manifests, this bug is not experienced by the user but can arise when the library is used.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests added

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Requires updates to the [Getting Started Guide](https://universalreference.io/docs/quick-start/)