### PR TITLE
fix: moves packages referenced in LDFLAGS to correct location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ GO_BUILD_BINDIR :=./bin
 GIT_COMMIT := $(or $(SOURCE_GIT_COMMIT),$(shell git rev-parse --short HEAD))
 GIT_TAG :="$(shell git tag | sort -V | tail -1)"
 
-GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/uor-client-go/cli.version="$(shell git tag | sort -V | tail -1)" \
-				   -X github.com/uor-framework/uor-client-go/cli.buildData="dev" \
-				   -X github.com/uor-framework/uor-client-go/cli.commit="$(GIT_COMMIT)" \
-				   -X github.com/uor-framework/uor-client-go/cli.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
+GO_LD_EXTRAFLAGS :=-X github.com/uor-framework/uor-client-go/cmd/client/commands.version="$(shell git tag | sort -V | tail -1)" \
+				   -X github.com/uor-framework/uor-client-go/cmd/client/commands.buildData="dev" \
+				   -X github.com/uor-framework/uor-client-go/cmd/client/commands.commit="$(GIT_COMMIT)" \
+				   -X github.com/uor-framework/uor-client-go/cmd/client/commands.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
 build: prep-build-dir
 	$(GO) build -o $(GO_BUILD_BINDIR)/uor-client-go  -ldflags="$(GO_LD_EXTRAFLAGS)" $(GO_BUILD_PACKAGES)


### PR DESCRIPTION
# Description

Update Makefile to point to the correct packages for version information when building

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`
uor-client-go version`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Requires updates to the [Getting Started Guide](https://universalreference.io/docs/quick-start/)