### PR TITLE
chore: extends timeout for GoReleaser CI job to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
   release:  
     needs: [linters, project]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     if: startsWith(github.ref, 'refs/tags/')
     steps:
     -


### PR DESCRIPTION
Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>